### PR TITLE
Jsign gt

### DIFF
--- a/common/rand.go
+++ b/common/rand.go
@@ -46,18 +46,15 @@ func (r *Rand) GetFr() (fr.Element, error) {
 	}
 }
 
-// TODO: this function is temporary. It returns a big.Int
-// from some random 128 bytes. It should be better defined
-// regarding the underlying group order.
-func (r *Rand) GetBigInt128() (big.Int, error) {
-	var byts [128]byte
-	if _, err := r.rand.Read(byts[:]); err != nil {
-		return big.Int{}, fmt.Errorf("get randomness: %s", err)
-
+func (r *Rand) GetFrBigInt() (big.Int, error) {
+	var randElem fr.Element
+	if _, err := randElem.SetRandom(); err != nil {
+		return big.Int{}, fmt.Errorf("get random GT: %s", err)
 	}
 	var scalar big.Int
-	scalar.SetBytes(byts[:])
-	return scalar, nil
+	randElem.BigInt(&scalar)
+
+	return *randElem.BigInt(&scalar), nil
 }
 
 func (r *Rand) GetFrs(n int) ([]fr.Element, error) {

--- a/common/rand.go
+++ b/common/rand.go
@@ -133,5 +133,5 @@ func (r *Rand) GetGt() (bls12381.GT, error) {
 		return bls12381.GT{}, fmt.Errorf("get random GT: %s", err)
 	}
 
-	return randElem, nil
+	return bls12381.FinalExponentiation(&randElem), nil
 }

--- a/group/gt.go
+++ b/group/gt.go
@@ -26,7 +26,7 @@ func FromGt(gt bls12381.GT) Element {
 
 func (z *GtElement) ScalarMultiplication(e Element, scalar *big.Int) Element {
 	ee := e.(*GtElement).inner
-	z.inner.Exp(ee, scalar)
+	z.inner.ExpGLV(ee, scalar)
 	return z
 }
 

--- a/samescalarargument/samescalarargument_test.go
+++ b/samescalarargument/samescalarargument_test.go
@@ -64,11 +64,11 @@ func TestProveVerify(t *testing.T) {
 			S, err := config.genRandomGroupElement()
 			require.NoError(t, err)
 
-			k, err := rand.GetBigInt128()
+			k, err := rand.GetFrBigInt()
 			require.NoError(t, err)
-			r_t, err := rand.GetBigInt128()
+			r_t, err := rand.GetFrBigInt()
 			require.NoError(t, err)
-			r_u, err := rand.GetBigInt128()
+			r_u, err := rand.GetFrBigInt()
 			require.NoError(t, err)
 
 			tmp := config.group.CreateElement()


### PR DESCRIPTION
* Added right sampling of element in G_T (remember that if this solution will fly it is going to be vital to check that element are in the right G_T group
* Added random sampling of an big integer to the Fr group (not 1024 element)
* Added ExpGLV usage (This speeds up exponentiation considerably)

I do not like how currently the Big integer are done mod the curve order but yeah it's just a poc