### PR TITLE
group: add constraint that order is r

### DIFF
--- a/common/rand.go
+++ b/common/rand.go
@@ -46,17 +46,6 @@ func (r *Rand) GetFr() (fr.Element, error) {
 	}
 }
 
-func (r *Rand) GetFrBigInt() (big.Int, error) {
-	var randElem fr.Element
-	if _, err := randElem.SetRandom(); err != nil {
-		return big.Int{}, fmt.Errorf("get random GT: %s", err)
-	}
-	var scalar big.Int
-	randElem.BigInt(&scalar)
-
-	return *randElem.BigInt(&scalar), nil
-}
-
 func (r *Rand) GetFrs(n int) ([]fr.Element, error) {
 	var err error
 	ret := make([]fr.Element, n)

--- a/group/g1.go
+++ b/group/g1.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 )
 
 type GroupG1 struct {
@@ -24,9 +25,11 @@ func FromG1Jac(g1Jac bls12381.G1Jac) Element {
 	}
 }
 
-func (z *G1Element) ScalarMultiplication(e Element, scalar *big.Int) Element {
+func (z *G1Element) ScalarMultiplication(e Element, scalar fr.Element) Element {
 	ee := e.(*G1Element).inner
-	z.inner.ScalarMultiplication(&ee, scalar)
+	var bi big.Int
+	scalar.BigInt(&bi)
+	z.inner.ScalarMultiplication(&ee, &bi)
 	return z
 }
 

--- a/group/group.go
+++ b/group/group.go
@@ -1,13 +1,15 @@
 package group
 
-import "math/big"
+import (
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+)
 
 type Group interface {
 	CreateElement() Element
 }
 
 type Element interface {
-	ScalarMultiplication(e Element, scalar *big.Int) Element
+	ScalarMultiplication(e Element, scalar fr.Element) Element
 	Set(e Element) Element
 	AddAssign(e Element) Element
 	Equal(e Element) bool
@@ -26,7 +28,7 @@ func NewGroupCommitment(
 	crsG Element,
 	crsH Element,
 	T Element,
-	r *big.Int,
+	r fr.Element,
 ) GroupCommitment {
 	T_1, T_2, tmp := group.CreateElement(), group.CreateElement(), group.CreateElement()
 	T_1.ScalarMultiplication(crsG, r)
@@ -51,7 +53,7 @@ func (gc *GroupCommitment) Add(cm GroupCommitment) GroupCommitment {
 	return ret
 }
 
-func (gc *GroupCommitment) Mul(scalar *big.Int) GroupCommitment {
+func (gc *GroupCommitment) Mul(scalar fr.Element) GroupCommitment {
 	ret := GroupCommitment{
 		g:   gc.g,
 		T_1: gc.g.CreateElement(),

--- a/group/gt.go
+++ b/group/gt.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 )
 
 type GroupGt struct {
@@ -24,9 +25,11 @@ func FromGt(gt bls12381.GT) Element {
 	}
 }
 
-func (z *GtElement) ScalarMultiplication(e Element, scalar *big.Int) Element {
+func (z *GtElement) ScalarMultiplication(e Element, scalar fr.Element) Element {
 	ee := e.(*GtElement).inner
-	z.inner.ExpGLV(ee, scalar)
+	var bi big.Int
+	scalar.BigInt(&bi)
+	z.inner.ExpGLV(ee, &bi)
 	return z
 }
 

--- a/samescalarargument/samescalarargument_test.go
+++ b/samescalarargument/samescalarargument_test.go
@@ -64,16 +64,16 @@ func TestProveVerify(t *testing.T) {
 			S, err := config.genRandomGroupElement()
 			require.NoError(t, err)
 
-			k, err := rand.GetFrBigInt()
+			k, err := rand.GetFr()
 			require.NoError(t, err)
-			r_t, err := rand.GetFrBigInt()
+			r_t, err := rand.GetFr()
 			require.NoError(t, err)
-			r_u, err := rand.GetFrBigInt()
+			r_u, err := rand.GetFr()
 			require.NoError(t, err)
 
 			tmp := config.group.CreateElement()
-			T := group.NewGroupCommitment(config.group, crs.Gt, crs.H, tmp.ScalarMultiplication(R, &k), &r_t)
-			U := group.NewGroupCommitment(config.group, crs.Gu, crs.H, tmp.ScalarMultiplication(S, &k), &r_u)
+			T := group.NewGroupCommitment(config.group, crs.Gt, crs.H, tmp.ScalarMultiplication(R, k), r_t)
+			U := group.NewGroupCommitment(config.group, crs.Gu, crs.H, tmp.ScalarMultiplication(S, k), r_u)
 
 			now := time.Now()
 			proof, err := Prove(

--- a/transcript/transcript.go
+++ b/transcript/transcript.go
@@ -2,7 +2,6 @@ package transcript
 
 import (
 	"bytes"
-	"math/big"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
@@ -68,15 +67,6 @@ func (t *Transcript) GetAndAppendChallenge(label []byte) fr.Element {
 			return challenge
 		}
 	}
-}
-
-// TEMP: experimental.
-func (t *Transcript) GetAndAppendChallengeBigInt(label []byte) big.Int {
-	var dest [128]byte
-	t.inner.ChallengeBytes(label, dest[:])
-	var challenge big.Int
-	challenge.SetBytes(dest[:])
-	return challenge
 }
 
 func (t *Transcript) GetAndAppendChallenges(label []byte, count int) []fr.Element {


### PR DESCRIPTION
Since we're trying with groups of order `Fr`, we can switch back from big.Int to Fr which makes the code a bit nicer.