### PR TITLE
innerproductargument: support for Gt

### DIFF
--- a/group/group.go
+++ b/group/group.go
@@ -1,7 +1,10 @@
 package group
 
 import (
+	"fmt"
+
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+	"github.com/jsign/curdleproofs/common"
 )
 
 type Group interface {
@@ -11,9 +14,11 @@ type Group interface {
 type Element interface {
 	ScalarMultiplication(e Element, scalar fr.Element) Element
 	Set(e Element) Element
+	Add(a, b Element) Element
 	AddAssign(e Element) Element
 	Equal(e Element) bool
 	Bytes() []byte
+	MultiExp([]Element, []fr.Element) (Element, error)
 }
 
 type GroupCommitment struct {
@@ -67,4 +72,74 @@ func (gc *GroupCommitment) Mul(scalar fr.Element) GroupCommitment {
 
 func (t GroupCommitment) Eq(cm GroupCommitment) bool {
 	return t.T_1.Equal(cm.T_1) && t.T_2.Equal(cm.T_2)
+}
+
+type MsmAccumulator struct {
+	g             Group
+	A_c           Element
+	baseScalarMap []msmCoeff
+}
+
+type msmCoeff struct {
+	basis  Element
+	scalar fr.Element
+}
+
+func NewMsmAccumulator(g Group) *MsmAccumulator {
+	return &MsmAccumulator{
+		g:             g,
+		A_c:           g.CreateElement(),
+		baseScalarMap: nil,
+	}
+}
+
+func (ma *MsmAccumulator) AccumulateCheck(
+	C Element,
+	scalar []fr.Element,
+	basis []Element,
+	rand *common.Rand) error {
+	if len(basis) != len(scalar) {
+		return fmt.Errorf("x and v must have the same length")
+	}
+
+	alpha, err := rand.GetFr()
+	if err != nil {
+		return fmt.Errorf("get random scalar: %s", err)
+	}
+
+	var tmp fr.Element
+outer:
+	for i := 0; i < len(basis); i++ {
+		tmp.Mul(&alpha, &scalar[i])
+
+		for j := range ma.baseScalarMap {
+			if ma.baseScalarMap[j].basis.Equal(basis[i]) {
+				var scalar fr.Element
+				scalar.Add(&ma.baseScalarMap[j].scalar, &tmp)
+				ma.baseScalarMap[j].scalar = scalar
+				continue outer
+			}
+		}
+		ma.baseScalarMap = append(ma.baseScalarMap, msmCoeff{basis: basis[i], scalar: tmp})
+	}
+	ma.A_c.AddAssign(C.ScalarMultiplication(C, alpha))
+
+	return nil
+}
+
+func (ma *MsmAccumulator) Verify() (bool, error) {
+	x := make([]fr.Element, 0, len(ma.baseScalarMap))
+	v := make([]Element, 0, len(ma.baseScalarMap))
+
+	for _, coeff := range ma.baseScalarMap {
+		v = append(v, coeff.basis)
+		x = append(x, coeff.scalar)
+	}
+
+	msmRes := ma.g.CreateElement()
+	if _, err := msmRes.MultiExp(v, x); err != nil {
+		return false, fmt.Errorf("computing msm: %s", err)
+	}
+
+	return msmRes.Equal(ma.A_c), nil
 }

--- a/group/gt.go
+++ b/group/gt.go
@@ -1,49 +1,73 @@
 package group
 
-// type GroupGt struct {
-// }
+import (
+	"math/big"
 
-// func (g *GroupGt) CreateElement() Element {
-// 	return &GtElement{}
-// }
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
+)
 
-// // GtElement implements Elemen backed by a Gt element.
-// type GtElement struct {
-// 	inner bls12381.GT
-// }
+type GroupGt struct {
+}
 
-// func FromGt(gt bls12381.GT) Element {
-// 	return &GtElement{
-// 		inner: gt,
-// 	}
-// }
+func (g *GroupGt) CreateElement() Element {
+	return &GtElement{}
+}
 
-// func (z *GtElement) ScalarMultiplication(e Element, scalar fr.Element) Element {
-// 	ee := e.(*GtElement).inner
-// 	var bi big.Int
-// 	scalar.BigInt(&bi)
-// 	z.inner.ExpGLV(ee, &bi)
-// 	return z
-// }
+// GtElement implements Elemen backed by a Gt element.
+type GtElement struct {
+	inner bls12381.GT
+}
 
-// func (z *GtElement) Set(e Element) Element {
-// 	ee := e.(*GtElement).inner
-// 	z.inner.Set(&ee)
-// 	return z
-// }
+func FromGt(gt bls12381.GT) Element {
+	return &GtElement{
+		inner: gt,
+	}
+}
 
-// func (z *GtElement) AddAssign(e Element) Element {
-// 	ee := e.(*GtElement).inner
-// 	z.inner.Mul(&z.inner, &ee)
-// 	return z
-// }
+func (z *GtElement) ScalarMultiplication(e Element, scalar fr.Element) Element {
+	ee := e.(*GtElement).inner
+	var bi big.Int
+	scalar.BigInt(&bi)
+	z.inner.ExpGLV(ee, &bi)
+	return z
+}
 
-// func (z *GtElement) Equal(e Element) bool {
-// 	ee := e.(*GtElement).inner
-// 	return z.inner.Equal(&ee)
-// }
+func (z *GtElement) Set(e Element) Element {
+	ee := e.(*GtElement).inner
+	z.inner.Set(&ee)
+	return z
+}
 
-// func (z *GtElement) Bytes() []byte {
-// 	res := z.inner.Bytes()
-// 	return res[:]
-// }
+func (z *GtElement) AddAssign(e Element) Element {
+	ee := e.(*GtElement).inner
+	z.inner.Mul(&z.inner, &ee)
+	return z
+}
+
+func (z *GtElement) Add(a, b Element) Element {
+	z.Set(a)
+	z.AddAssign(b)
+	return z
+}
+
+func (z *GtElement) MultiExp(basis []Element, scalars []fr.Element) (Element, error) {
+	// Maybe quite naive; but it works. Prob could use some Pippenger algorithm?
+	z.inner = bls12381.GT{}
+	for i := 0; i < len(basis); i++ {
+		var tmp GtElement
+		tmp.ScalarMultiplication(basis[i], scalars[i])
+		z.AddAssign(&tmp)
+	}
+	return z, nil
+}
+
+func (z *GtElement) Equal(e Element) bool {
+	ee := e.(*GtElement).inner
+	return z.inner.Equal(&ee)
+}
+
+func (z *GtElement) Bytes() []byte {
+	res := z.inner.Bytes()
+	return res[:]
+}

--- a/group/gt.go
+++ b/group/gt.go
@@ -1,56 +1,49 @@
 package group
 
-import (
-	"math/big"
+// type GroupGt struct {
+// }
 
-	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
-	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
-)
+// func (g *GroupGt) CreateElement() Element {
+// 	return &GtElement{}
+// }
 
-type GroupGt struct {
-}
+// // GtElement implements Elemen backed by a Gt element.
+// type GtElement struct {
+// 	inner bls12381.GT
+// }
 
-func (g *GroupGt) CreateElement() Element {
-	return &GtElement{}
-}
+// func FromGt(gt bls12381.GT) Element {
+// 	return &GtElement{
+// 		inner: gt,
+// 	}
+// }
 
-// GtElement implements Elemen backed by a Gt element.
-type GtElement struct {
-	inner bls12381.GT
-}
+// func (z *GtElement) ScalarMultiplication(e Element, scalar fr.Element) Element {
+// 	ee := e.(*GtElement).inner
+// 	var bi big.Int
+// 	scalar.BigInt(&bi)
+// 	z.inner.ExpGLV(ee, &bi)
+// 	return z
+// }
 
-func FromGt(gt bls12381.GT) Element {
-	return &GtElement{
-		inner: gt,
-	}
-}
+// func (z *GtElement) Set(e Element) Element {
+// 	ee := e.(*GtElement).inner
+// 	z.inner.Set(&ee)
+// 	return z
+// }
 
-func (z *GtElement) ScalarMultiplication(e Element, scalar fr.Element) Element {
-	ee := e.(*GtElement).inner
-	var bi big.Int
-	scalar.BigInt(&bi)
-	z.inner.ExpGLV(ee, &bi)
-	return z
-}
+// func (z *GtElement) AddAssign(e Element) Element {
+// 	ee := e.(*GtElement).inner
+// 	z.inner.Mul(&z.inner, &ee)
+// 	return z
+// }
 
-func (z *GtElement) Set(e Element) Element {
-	ee := e.(*GtElement).inner
-	z.inner.Set(&ee)
-	return z
-}
+// func (z *GtElement) Equal(e Element) bool {
+// 	ee := e.(*GtElement).inner
+// 	return z.inner.Equal(&ee)
+// }
 
-func (z *GtElement) AddAssign(e Element) Element {
-	ee := e.(*GtElement).inner
-	z.inner.Mul(&z.inner, &ee)
-	return z
-}
-
-func (z *GtElement) Equal(e Element) bool {
-	ee := e.(*GtElement).inner
-	return z.inner.Equal(&ee)
-}
-
-func (z *GtElement) Bytes() []byte {
-	res := z.inner.Bytes()
-	return res[:]
-}
+// func (z *GtElement) Bytes() []byte {
+// 	res := z.inner.Bytes()
+// 	return res[:]
+// }

--- a/innerproductargument/innerproductargument_test.go
+++ b/innerproductargument/innerproductargument_test.go
@@ -1,98 +1,143 @@
 package innerproductargument
 
 import (
-	"bytes"
 	"testing"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
 	"github.com/jsign/curdleproofs/common"
-	"github.com/jsign/curdleproofs/msmaccumulator"
+	"github.com/jsign/curdleproofs/group"
 	"github.com/jsign/curdleproofs/transcript"
 	"github.com/stretchr/testify/require"
 )
+
+type testConfig struct {
+	name                  string
+	group                 group.Group
+	genRandomGroupElement func(*common.Rand) (group.Element, error)
+}
 
 func TestInnerProductArgument(t *testing.T) {
 	t.Parallel()
 
 	n := 128
-	var proof Proof
-	{
-		transcript := transcript.New([]byte("IPA"))
-		crs, B, C, z, bs, cs, _ := setup(t, n)
 
-		rand, err := common.NewRand(42)
-		require.NoError(t, err)
-		proof, err = Prove(
-			crs,
-			B,
-			C,
-			z,
-			bs,
-			cs,
-			transcript,
-			rand,
-		)
-		require.NoError(t, err)
+	configs := []testConfig{
+		{
+			name:  "G1",
+			group: &group.GroupG1{},
+			genRandomGroupElement: func(rand *common.Rand) (group.Element, error) {
+				randG1Aff, err := rand.GetG1Affine()
+				if err != nil {
+					return nil, err
+				}
+				var randG1Jac bls12381.G1Jac
+				randG1Jac.FromAffine(&randG1Aff)
+				return group.FromG1Jac(randG1Jac), nil
+			},
+		},
+		// {
+		// 	name:  "Gt",
+		// 	group: &group.GroupGt{},
+		// 	genRandomGroupElement: func() (group.Element, error) {
+		// 		randGt, err := rand.GetGt()
+		// 		if err != nil {
+		// 			return nil, err
+		// 		}
+		// 		return group.FromGt(randGt), nil
+		// 	},
+		// },
+	}
+	for _, config := range configs {
+		t.Run(config.name, func(t *testing.T) {
+
+			var proof Proof
+			{
+				transcript := transcript.New([]byte("IPA"))
+				crs, B, C, z, bs, cs, _ := setup(t, config, n)
+
+				rand, err := common.NewRand(42)
+				require.NoError(t, err)
+				proof, err = Prove(
+					config.group,
+					crs,
+					B,
+					C,
+					z,
+					bs,
+					cs,
+					transcript,
+					rand,
+				)
+				require.NoError(t, err)
+			}
+
+			t.Run("completeness", func(t *testing.T) {
+				transcript := transcript.New([]byte("IPA"))
+				msmAccumulator := group.NewMsmAccumulator(config.group)
+				crs, B, C, z, _, _, us := setup(t, config, n)
+
+				rand, err := common.NewRand(43)
+				require.NoError(t, err)
+
+				ok, err := Verify(
+					config.group,
+					proof,
+					crs,
+					B,
+					C,
+					z,
+					us,
+					transcript,
+					msmAccumulator,
+					rand,
+				)
+				require.NoError(t, err)
+				require.True(t, ok)
+
+				ok, err = msmAccumulator.Verify()
+				require.NoError(t, err)
+				require.True(t, ok)
+			})
+		})
 	}
 
-	t.Run("completeness", func(t *testing.T) {
-		transcript := transcript.New([]byte("IPA"))
-		msmAccumulator := msmaccumulator.New()
-		crs, B, C, z, _, _, us := setup(t, n)
+	// t.Run("encode/decode", func(t *testing.T) {
+	// 	buf := bytes.NewBuffer(nil)
+	// 	require.NoError(t, proof.Serialize(buf))
+	// 	expected := buf.Bytes()
 
-		rand, err := common.NewRand(43)
-		require.NoError(t, err)
+	// 	var proof2 Proof
+	// 	require.NoError(t, proof2.FromReader(buf))
 
-		ok, err := Verify(
-			proof,
-			crs,
-			B,
-			C,
-			z,
-			us,
-			transcript,
-			msmAccumulator,
-			rand,
-		)
-		require.NoError(t, err)
-		require.True(t, ok)
+	// 	buf2 := bytes.NewBuffer(nil)
+	// 	require.NoError(t, proof2.Serialize(buf2))
 
-		ok, err = msmAccumulator.Verify()
-		require.NoError(t, err)
-		require.True(t, ok)
-	})
-
-	t.Run("encode/decode", func(t *testing.T) {
-		buf := bytes.NewBuffer(nil)
-		require.NoError(t, proof.Serialize(buf))
-		expected := buf.Bytes()
-
-		var proof2 Proof
-		require.NoError(t, proof2.FromReader(buf))
-
-		buf2 := bytes.NewBuffer(nil)
-		require.NoError(t, proof2.Serialize(buf2))
-
-		require.Equal(t, expected, buf2.Bytes())
-	})
+	// 	require.Equal(t, expected, buf2.Bytes())
+	// })
 }
 
-func setup(t *testing.T, n int) (CRS, bls12381.G1Jac, bls12381.G1Jac, fr.Element, []fr.Element, []fr.Element, []fr.Element) {
+func setup(t *testing.T, config testConfig, n int) (CRS, group.Element, group.Element, fr.Element, []fr.Element, []fr.Element, []fr.Element) {
 	rand, err := common.NewRand(0)
 	require.NoError(t, err)
 
-	crsGs, err := rand.GetG1Affines(n)
-	require.NoError(t, err)
+	crsGs := make([]group.Element, n)
+	for i := range crsGs {
+		crsGs[i], err = config.genRandomGroupElement(rand)
+		require.NoError(t, err)
+	}
 	// There is actually a relationship between crs_G_vec and crs_G_prime_vec because of the grandproduct optimization
 	// We generate a `vec_u` which has the discrete logs of every crs_G_prime element with respect to crs_G
 	us, err := rand.GetFrs(n)
 	require.NoError(t, err)
-	crsGs_prime := make([]bls12381.G1Affine, n)
-	for i := 0; i < n; i++ {
-		crsGs_prime[i].ScalarMultiplication(&crsGs[i], common.FrToBigInt(&us[i]))
+	crsGs_prime := make([]group.Element, n)
+	for i := range crsGs_prime {
+		crsGs_prime[i] = config.group.CreateElement()
 	}
-	H, err := rand.GetG1Jac()
+	for i := 0; i < n; i++ {
+		crsGs_prime[i].ScalarMultiplication(crsGs[i], us[i])
+	}
+	H, err := config.genRandomGroupElement(rand)
 	require.NoError(t, err)
 	crs := CRS{
 		Gs:       crsGs,
@@ -110,11 +155,11 @@ func setup(t *testing.T, n int) (CRS, bls12381.G1Jac, bls12381.G1Jac, fr.Element
 	require.NoError(t, err)
 
 	// Create commitments
-	var B bls12381.G1Jac
-	_, err = B.MultiExp(crs.Gs, bs, common.MultiExpConf)
+	B := config.group.CreateElement()
+	_, err = B.MultiExp(crs.Gs, bs)
 	require.NoError(t, err)
-	var C bls12381.G1Jac
-	_, err = C.MultiExp(crs.Gs_prime, cs, common.MultiExpConf)
+	C := config.group.CreateElement()
+	_, err = C.MultiExp(crs.Gs_prime, cs)
 	require.NoError(t, err)
 
 	return crs, B, C, z, bs, cs, us

--- a/innerproductargument/innerproductargument_test.go
+++ b/innerproductargument/innerproductargument_test.go
@@ -1,7 +1,9 @@
 package innerproductargument
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
 	"github.com/consensys/gnark-crypto/ecc/bls12-381/fr"
@@ -58,6 +60,7 @@ func TestInnerProductArgument(t *testing.T) {
 
 				rand, err := common.NewRand(42)
 				require.NoError(t, err)
+				start := time.Now()
 				proof, err = Prove(
 					config.group,
 					crs,
@@ -70,6 +73,7 @@ func TestInnerProductArgument(t *testing.T) {
 					rand,
 				)
 				require.NoError(t, err)
+				fmt.Printf("Prove for %s took %s\n", config.name, time.Since(start))
 			}
 
 			t.Run("completeness", func(t *testing.T) {
@@ -80,6 +84,7 @@ func TestInnerProductArgument(t *testing.T) {
 				rand, err := common.NewRand(43)
 				require.NoError(t, err)
 
+				startVerify := time.Now()
 				ok, err := Verify(
 					config.group,
 					proof,
@@ -95,9 +100,11 @@ func TestInnerProductArgument(t *testing.T) {
 				require.NoError(t, err)
 				require.True(t, ok)
 
+				startMsmAccumCheck := time.Now()
 				ok, err = msmAccumulator.Verify()
 				require.NoError(t, err)
 				require.True(t, ok)
+				fmt.Printf("Verify for %s took %s (%s+%s)\n", config.name, time.Since(startVerify), startMsmAccumCheck.Sub(startVerify), time.Since(startMsmAccumCheck))
 			})
 		})
 	}

--- a/innerproductargument/innerproductargument_test.go
+++ b/innerproductargument/innerproductargument_test.go
@@ -36,17 +36,17 @@ func TestInnerProductArgument(t *testing.T) {
 				return group.FromG1Jac(randG1Jac), nil
 			},
 		},
-		// {
-		// 	name:  "Gt",
-		// 	group: &group.GroupGt{},
-		// 	genRandomGroupElement: func() (group.Element, error) {
-		// 		randGt, err := rand.GetGt()
-		// 		if err != nil {
-		// 			return nil, err
-		// 		}
-		// 		return group.FromGt(randGt), nil
-		// 	},
-		// },
+		{
+			name:  "Gt",
+			group: &group.GroupGt{},
+			genRandomGroupElement: func(rand *common.Rand) (group.Element, error) {
+				randGt, err := rand.GetGt()
+				if err != nil {
+					return nil, err
+				}
+				return group.FromGt(randGt), nil
+			},
+		},
 	}
 	for _, config := range configs {
 		t.Run(config.name, func(t *testing.T) {


### PR DESCRIPTION
This PR adds support for an abstract group to `innerproductargument`, which means can now run in Gt.

You now can run: `go test ./innerproductargument -v -count=1` to run the test/naive-bench as done with `samescalarargument`:
```
=== RUN   TestInnerProductArgument/G1
Prove for G1 took 51.565106ms
=== RUN   TestInnerProductArgument/G1/completeness
Verify for G1 took 92.228526ms (91.284128ms+944.629µs)
=== RUN   TestInnerProductArgument/Gt
Prove for Gt took 363.164665ms
=== RUN   TestInnerProductArgument/Gt/completeness
Verify for Gt took 57.649203ms (12.271846ms+45.377507ms)
--- PASS: TestInnerProductArgument (0.98s)
    --- PASS: TestInnerProductArgument/G1 (0.20s)
        --- PASS: TestInnerProductArgument/G1/completeness (0.12s)
    --- PASS: TestInnerProductArgument/Gt (0.78s)
        --- PASS: TestInnerProductArgument/Gt/completeness (0.24s)
PASS
ok      github.com/jsign/curdleproofs/innerproductargument      0.984s
```

Migrating this argument took some extra work since I had to:
- Add `Add` and `MultiExp` to the abstract group interface (and impls)
- Generalize the MSM Accumulator.

I'll add some PR comments to explain a bit further.
